### PR TITLE
Allow `tel` as input time.

### DIFF
--- a/src/ReactCodeInput.js
+++ b/src/ReactCodeInput.js
@@ -205,7 +205,7 @@ ReactCodeInput.defaultProps = {
 }
 ReactCodeInput.propTypes = {
   options: PropTypes.object,
-  type: PropTypes.oneOf(['text', 'number', 'password']),
+  type: PropTypes.oneOf(['text', 'number', 'password', 'tel']),
   fields: PropTypes.number,
   value: PropTypes.string,
   onChange: PropTypes.func,


### PR DESCRIPTION
This is useful if you want to grant the user ability to display pad-like input for code

![image](https://user-images.githubusercontent.com/7795177/30193659-43967f24-9446-11e7-9025-777244341a63.png)
