### PR TITLE
Add an ability to disable autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ const props = {
 | inputStyleInvalid | object | Setting the styles of each input field if `isValid` prop is `false`. |
 | isValid | bool | Returns true if an input element contains valid data. |
 | disabled | bool | When present, it specifies that the element should be disabled. |
+| autoFocus | bool | Setup autofocus on the first input, `true` by default. |
 
 ## Compatible with
 [`redux-form`](https://github.com/erikras/redux-form) from [erikras](https://github.com/erikras)

--- a/src/ReactCodeInput.js
+++ b/src/ReactCodeInput.js
@@ -165,7 +165,7 @@ class ReactCodeInput extends Component {
   }
 
   render() {
-    const { className, style = {}, inputStyle = {}, inputStyleInvalid = {}, type } = this.props,
+    const { className, style = {}, inputStyle = {}, inputStyleInvalid = {}, type, autoFocus } = this.props,
           { disabled, input, isValid, defaultInputStyle } = this.state,
           styles = {
             container: style,
@@ -212,7 +212,7 @@ class ReactCodeInput extends Component {
                this.textInput[i] = ref
              }}
              id={i}
-             autoFocus={(i === 0) ? 'autoFocus' : ''}
+             autoFocus={autoFocus && (i === 0) ? 'autoFocus' : ''}
              defaultValue={value}
              key={`input_${i}`}
              type={type}
@@ -236,6 +236,7 @@ class ReactCodeInput extends Component {
 }
 
 ReactCodeInput.defaultProps = {
+  autoFocus: true,
   isValid: true,
   disabled: false,
   fields: 4,
@@ -254,6 +255,7 @@ ReactCodeInput.propTypes = {
   className: PropTypes.string,
   isValid: PropTypes.bool,
   disabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   style: PropTypes.object,
   inputStyle: PropTypes.object,
   inputStyleInvalid: PropTypes.object


### PR DESCRIPTION
I found that currently "autoFocus" is enabled by default and there is no option to disable it. But in some cases - it is not required to focus on the first element. So here is small PR for it :)