### PR TITLE
Fix right-padding issue on iOS

### DIFF
--- a/src/ReactCodeInput.js
+++ b/src/ReactCodeInput.js
@@ -43,6 +43,7 @@ class ReactCodeInput extends Component {
         boxShadow: '0px 0px 10px 0px rgba(0,0,0,.10)',
         margin: '4px',
         paddingLeft: '8px',
+        paddingRight: 0,
         width: '36px',
         height: '42px',
         fontSize: '32px',


### PR DESCRIPTION
On iOS, the component renders as follows on both Safari and Chrome (as tested on an iPad with iOS 12.1.4):

![image](https://user-images.githubusercontent.com/1915543/53307417-44aac880-3890-11e9-92bc-9a71f74d4a6a.png)

Setting the `defaultInputStyle` to set the padding-right fixes this, and causes no apparent issues on other browsers.