### PR TITLE
Added prevent typing letters if the type is number for Safari & Firefox

### DIFF
--- a/src/ReactCodeInput.js
+++ b/src/ReactCodeInput.js
@@ -153,6 +153,7 @@ class ReactCodeInput extends Component {
   }
 
   handleKeyDown(e) {
+    const isNumeric = /^\d*$/.test(e.key);
     const target = Number(e.target.dataset.id),
       nextTarget = this.textInput[target + 1],
       prevTarget = this.textInput[target - 1];
@@ -222,6 +223,11 @@ class ReactCodeInput extends Component {
 
       default:
         break;
+    }
+
+    // Prevents typing letters if the type is number for Safari & Firefox
+    if (e.target.type === 'number' && !isNumeric) {
+      e.preventDefault();
     }
 
     this.handleTouch(value);


### PR DESCRIPTION
Currently, react-code-input has a bug in value validation.
In Safari and Firefox, it's possible to type letters when the react-code-input component receives 'numeric' type.
Google and Opera work correctly.