### PR TITLE
Add autoComplete type.

### DIFF
--- a/src/ReactCodeInput.d.ts
+++ b/src/ReactCodeInput.d.ts
@@ -73,6 +73,9 @@ export interface ReactCodeInputProps {
     // The inputMode prop tells the browser on devices with dynamic keyboards which keyboard to display.
     inputMode: InputModeTypes
 
+    // The autoComplete prop specifies whether or not an input field should have autocomplete enabled.
+    autoComplete?: string
+
 }
 
 declare class ReactCodeInput extends Component<ReactCodeInputProps, any> {


### PR DESCRIPTION
This is to address a bug that causes an error when using the autoComplete attribute in TypeScript.